### PR TITLE
Refine zodiac cusp dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,17 +11,17 @@
 
 <ol class="galaxy font-mono">
   <li class="madlib"><span class="zodiac-aries">03/21...aries is sparking shit.</span>
-  <li class="madlib"><span class="zodiac-taurus">04/21...taurus is core of the earth.</span>
-  <li class="madlib"><span class="zodiac-gemini">05/22...gemini is the challenger.</span>
-  <li class="madlib"><span class="zodiac-cancer">06/22...cancer is changing perspectives.</span>
+  <li class="madlib"><span class="zodiac-taurus">04/20...taurus is core of the earth.</span>
+  <li class="madlib"><span class="zodiac-gemini">05/21...gemini is the challenger.</span>
+  <li class="madlib"><span class="zodiac-cancer">06/21...cancer is changing perspectives.</span>
   <li class="madlib"><span class="zodiac-leo">07/23...leo is a fire-eating fire.</span>
   <li class="madlib"><span class="zodiac-virgo">08/23...virgo is justice.</span>
-  <li class="madlib"><span class="zodiac-libra">09/24...libra is a friend.</span>
-  <li class="madlib"><span class="zodiac-scorpio">10/24...scorpio is inspiration.</span>
-  <li class="madlib"><span class="zodiac-sagittarius">11/23...sagittarius is quiet impact.</span>
+  <li class="madlib"><span class="zodiac-libra">09/23...libra is a friend.</span>
+  <li class="madlib"><span class="zodiac-scorpio">10/23...scorpio is inspiration.</span>
+  <li class="madlib"><span class="zodiac-sagittarius">11/22...sagittarius is quiet impact.</span>
   <li class="madlib"><span class="zodiac-capricorn">12/22...capricorn is seeking security.</span>
-  <li class="madlib"><span class="zodiac-aquarius">01/21...aquarius is telling jokes.</span>
-  <li class="madlib"><span class="zodiac-pisces">02/20...pisces is a smooth rock.</span>
+  <li class="madlib"><span class="zodiac-aquarius">01/20...aquarius is telling jokes.</span>
+  <li class="madlib"><span class="zodiac-pisces">02/19...pisces is a smooth rock.</span>
 </ol>
 
 <figure class="cluster font-mono">


### PR DESCRIPTION
Adjust dates to be what seems most accepted for cusps. These now match [<b>Wikipedia: Astrological sign</b>](https://en.wikipedia.org/wiki/Astrological_sign#Western_zodiac_signs) and [astrostyle](https://astrostyle.com/zodiac-sign-dates/) whereas before we matched [Wikipedia: Zodiac](https://en.wikipedia.org/wiki/Zodiac). Also for example if you search Google like 4/20 zodiac sign Google says Taurus. I checked this update all like that in Google too