### PR TITLE
Opensource with a Z

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+# zlib license <br> [&copy; s9a](https://github.com/s9a)
+
+```
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+```


### PR DESCRIPTION
Heyyy @bonniezhou I've been nerding out lately and would like to include an opensource license here [from these](https://github.com/s9a/licenses)

Nominating `Zlib` because of [its features](https://github.com/s9a/tape/blob/master/LICENSE.md), its Z, [plus what I wrote online](https://s9a.page/license) but open to others from there if you desire